### PR TITLE
ProxySQL service should not be start immediately after package installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 ### Added
 ### Removed
 ### Fixed
+*[#3](https://github.com/idealista/proxysql_role/issues/3) [BUG] ProxySQL service should not be start immediately after package installation* @emepege
 ## [1.0.0](https://github.com/idealista/proxysql_role/tree/1.0.0)
 ### Added
 - *Initial release* @emepege

--- a/tasks/official_install.yml
+++ b/tasks/official_install.yml
@@ -36,6 +36,7 @@
       apt:
         pkg: "{{ proxysql_packages }}"
         state: present
+        policy_rc_d: 101
   when: proxysql_force_reinstall or proxysql_check is failed or proxysql_version not in proxysql_check.stdout
   tags:
     - proxysql_install

--- a/tasks/percona_install.yml
+++ b/tasks/percona_install.yml
@@ -34,6 +34,7 @@
       apt:
         pkg: "{{ proxysql_packages }}"
         state: present
+        policy_rc_d: 101
   when: proxysql_force_reinstall or proxysql_check is failed or proxysql_version not in proxysql_check.stdout
   tags:
     - proxysql_install


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;
* Add "idealista/benders" as reviewer

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Force the exit code of /usr/sbin/policy-rc.d to 101 in order to prevent the installed package will trigger a service start.

### Benefits

Fix #3

### Possible Drawbacks

None AFAIK.

### Applicable Issues

#3
