### PR TITLE
Wait until proxysql is up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 ### Added
 ### Removed
 ### Fixed
+*[#6](https://github.com/idealista/proxysql_role/issues/6) [BUG] Wait until proxysql service is up* @emepege
 ## [1.0.1](https://github.com/idealista/proxysql_role/tree/1.0.1)
 ### Fixed
 *[#3](https://github.com/idealista/proxysql_role/issues/3) [BUG] ProxySQL service should not be start immediately after package installation* @emepege

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -47,6 +47,10 @@
     state: started
     enabled: "{{ proxysql_service_enabled }}"
     daemon_reload: true
+  register: proxysqlDetails
+  until: proxysqlDetails.status.ActiveState == "active"
+  retries: 15
+  delay: 10
   tags:
     - proxysql_configure
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;
* Add "idealista/benders" as reviewer

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->
Added some options in a task to wait until proxysql service is up.

### Benefits

Resolve #6

### Possible Drawbacks

None AFAIK.

### Applicable Issues

#6
